### PR TITLE
Fix: 레이아웃 css 수정, 타이틀 컨테이너 제목 페이지마다 다르게 수정 #42

### DIFF
--- a/src/components/Layout/SideBar/index.tsx
+++ b/src/components/Layout/SideBar/index.tsx
@@ -1,12 +1,16 @@
-import { useEffect } from 'react';
 import { NavLink, Link } from 'react-router-dom';
 import { SidebarContainer, SidebarMenus, Submenus, MenuBadge } from './style';
 import logo from '@/assets/logo.png';
-import { useStepStore } from '@/store/store';
+import { useStepStore, useTitleStore } from '@/store/store';
 import RecentHistory from './RecentHistory';
 
 const SideBar = () => {
-  const { step, setStep } = useStepStore();
+  const { step } = useStepStore();
+  const { setTitle } = useTitleStore();
+
+  const handleMenuClick = (menuName: string) => {
+    setTitle(menuName);
+  };
 
   return (
     <SidebarContainer>
@@ -14,7 +18,11 @@ const SideBar = () => {
         <img className="logo" src={logo} alt="logo" />
       </NavLink>
       <SidebarMenus>
-        <NavLink className={step !== 0 ? 'mainmenu active' : 'mainmenu'} to="pra">
+        <NavLink
+          className={step !== 0 ? 'mainmenu active' : 'mainmenu'}
+          to="pra"
+          onClick={() => handleMenuClick('심사하기')}
+        >
           심사하기
         </NavLink>
         <Submenus className={step !== 0 ? '' : 'hide'}>
@@ -32,7 +40,7 @@ const SideBar = () => {
           className="mainmenu"
           to="/myreviews"
           onClick={() => {
-            setStep(0);
+            handleMenuClick('내 심사관리');
           }}
         >
           내 심사관리

--- a/src/components/Layout/Title/index.tsx
+++ b/src/components/Layout/Title/index.tsx
@@ -1,11 +1,13 @@
-import { useStepStore } from '@/store/store';
+import { useStepStore, useTitleStore } from '@/store/store';
 import { TitleWrapper } from './style';
 
 const Title = () => {
   const { step } = useStepStore();
+  const { currentTitle } = useTitleStore();
+
   return (
     <TitleWrapper>
-      <p>심사하기</p>
+      <p>{currentTitle}</p>
       {step === 2 ? (
         <div>
           <button type="button">PDF로 저장하기</button>

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -42,7 +42,7 @@ const Layout = () => {
           </MainSection>
         </>
       ) : (
-        <div className="pra">
+        <div className="combineSection">
           <Outlet />
         </div>
       )}

--- a/src/components/Layout/style.tsx
+++ b/src/components/Layout/style.tsx
@@ -12,8 +12,9 @@ export const LayoutContainer = styled.div`
     'a c d';
   overflow-y: hidden;
 
-  .pra {
+  .combineSection {
     grid-column: 2/ -1;
+    grid-row: 2/ -1;
   }
 
   /* 1920 미만 */

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -44,11 +44,21 @@ interface StspState {
   step: number;
   setStep: (num: number) => void;
 }
-
-// step 1은 등기부 업로드, step 2는 심사 내역 확인, step 3는 심사 종료(심사페이지 벗어나기), step 0은 그 외
+// step 1은 등기부 업로드, step 2는 심사 내역 확인, step 0은 그 외
 export const useStepStore = create<StspState>((set) => ({
   step: 0,
   setStep: (num) => {
     set((state) => ({ step: num }));
+  },
+}));
+
+interface TitleState {
+  currentTitle: string | null;
+  setTitle: (menuName: string) => void;
+}
+export const useTitleStore = create<TitleState>((set) => ({
+  currentTitle: null,
+  setTitle: (menuName) => {
+    set((state) => ({ currentTitle: menuName }));
   },
 }));


### PR DESCRIPTION
등기부 등록 페이지와 내 심사관리의 grid  row가 끝까지 설정되지 않은 것 수정.

메뉴 누르면, 메뉴 이름이 타이틀로 상태 저장되도록 변경